### PR TITLE
Fix SQL syntax for recent MySQL and use Digest::SHA instead of SHA1

### DIFF
--- a/DocDB/cgi/DocumentDatabase
+++ b/DocDB/cgi/DocumentDatabase
@@ -60,9 +60,9 @@ if ($UserValidation eq "certificate") {
 
 print $query->header( -charset => $HTTP_ENCODING );
 if ($UserValidation eq "certificate" && $CertificateStatus ne "verified") {
-  DocDBHeader("$Project Document Database","Document Database", -scripts => ["PopUps"], -refresh => "5;url=$CertificateApplyForm");
+  DocDBHeader("$Project Document Database","$Project Document Database", -scripts => ["PopUps"], -refresh => "5;url=$CertificateApplyForm");
 } else {
-  DocDBHeader("$Project Document Database","Document Database", -scripts => ["PopUps"]);
+  DocDBHeader("$Project Document Database","$Project Document Database", -scripts => ["PopUps"]);
 }
 
 my $PersonalAccountLink = PersonalAccountLink();

--- a/DocDB/cgi/EmailSecurity.pm
+++ b/DocDB/cgi/EmailSecurity.pm
@@ -147,7 +147,7 @@ sub UserPrefForm ($) {
 }
 
 sub EmailUserDigest ($) {
-  use Digest::SHA1 qw(sha1_hex);
+  use Digest::SHA qw(sha1_hex);
   my ($EmailUserID) = @_;
   &FetchEmailUser($EmailUserID);
 

--- a/DocDB/sql/CreateDatabase.SQL
+++ b/DocDB/sql/CreateDatabase.SQL
@@ -12,10 +12,10 @@ CREATE TABLE Author (
   LastName varchar(32) NOT NULL default '',
   InstitutionID int(11) NOT NULL default '0',
   Active int(11) default '1',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (AuthorID),
   KEY Name (LastName)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Author`
@@ -31,10 +31,10 @@ CREATE TABLE AuthorHint (
   AuthorHintID int(11) NOT NULL auto_increment,
   SessionTalkID int(11) default NULL,
   AuthorID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (AuthorHintID),
   KEY SessionTalkID (SessionTalkID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `AuthorHint`
@@ -52,7 +52,7 @@ CREATE TABLE Conference (
   URL varchar(240) default NULL,
   StartDate date default NULL,
   EndDate date default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   Title varchar(128) default NULL,
   Preamble text,
   Epilogue text,
@@ -63,7 +63,7 @@ CREATE TABLE Conference (
   PRIMARY KEY  (ConferenceID),
   KEY StartDate (StartDate),
   KEY EndDate (EndDate)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Conference`
@@ -92,12 +92,12 @@ CREATE TABLE ConfigSetting (
   Sub5Value varchar(64) default NULL,
   Description text,
   Constrained int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (ConfigSettingID),
   KEY ConfigGroup (ConfigGroup),
   KEY Sub1Group (Sub1Group),
   KEY ForeignID (ForeignID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `ConfigSetting`
@@ -114,10 +114,10 @@ CREATE TABLE ConfigValue (
   ConfigSettingID int(11) default NULL,
   Value varchar(64) default NULL,
   Description text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (ConfigValueID),
   KEY ConfigSettingID (ConfigSettingID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `ConfigValue`
@@ -133,13 +133,13 @@ CREATE TABLE DocXRef (
   DocXRefID int(11) NOT NULL auto_increment,
   DocRevID int(11) default NULL,
   DocumentID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   Version int(11) default NULL,
   Project varchar(32) default NULL,
   PRIMARY KEY  (DocXRefID),
   KEY DocRevID (DocRevID),
   KEY DocumentID (DocumentID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `DocXRef`
@@ -155,13 +155,13 @@ CREATE TABLE Document (
   DocumentID int(11) NOT NULL auto_increment,
   RequesterID int(11) NOT NULL default '0',
   RequestDate datetime default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   DocHash char(32) default NULL,
   Alias varchar(255) default NULL,
   PRIMARY KEY  (DocumentID),
   KEY Requester (RequesterID),
   KEY Alias (Alias)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Document`
@@ -179,11 +179,11 @@ CREATE TABLE DocumentFile (
   FileName varchar(255) NOT NULL default '',
   Date datetime default NULL,
   RootFile tinyint(4) default '1',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   Description varchar(128) default NULL,
   PRIMARY KEY  (DocFileID),
   KEY DocRevID (DocRevID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `DocumentFile`
@@ -204,7 +204,7 @@ CREATE TABLE DocumentRevision (
   VersionNumber int(11) NOT NULL default '0',
   Abstract text,
   RevisionDate datetime default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   Obsolete tinyint(4) default '0',
   Keywords varchar(240) default NULL,
   Note text,
@@ -214,7 +214,7 @@ CREATE TABLE DocumentRevision (
   KEY DocumentID (DocumentID),
   KEY DocumentTitle (DocumentTitle),
   KEY VersionNumber (VersionNumber)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `DocumentRevision`
@@ -230,9 +230,9 @@ CREATE TABLE DocumentType (
   DocTypeID int(11) NOT NULL auto_increment,
   ShortType varchar(32) default NULL,
   LongType varchar(255) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (DocTypeID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `DocumentType`
@@ -251,12 +251,12 @@ CREATE TABLE EmailUser (
   Name char(128) NOT NULL default '',
   EmailAddress char(64) NOT NULL default '',
   PreferHTML int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   CanSign int(11) NOT NULL default '0',
   Verified int(11) NOT NULL default '0',
   AuthorID int(11) NOT NULL default '0',
   PRIMARY KEY  (EmailUserID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `EmailUser`
@@ -272,9 +272,9 @@ CREATE TABLE EventGroup (
   EventGroupID int(11) NOT NULL auto_increment,
   ShortDescription varchar(32) NOT NULL default '',
   LongDescription text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (EventGroupID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `EventGroup`
@@ -292,13 +292,13 @@ CREATE TABLE EventTopic (
   EventID int(11) NOT NULL default '0',
   SessionID int(11) NOT NULL default '0',
   SessionSeparatorID int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (EventTopicID),
   KEY Topic (TopicID),
   KEY Event (EventID),
   KEY Session (SessionID),
   KEY SepKey (SessionSeparatorID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `EventTopic`
@@ -316,9 +316,9 @@ CREATE TABLE ExternalDocDB (
   Description varchar(255) default NULL,
   PublicURL varchar(255) default NULL,
   PrivateURL varchar(255) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (ExternalDocDBID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `ExternalDocDB`
@@ -334,9 +334,9 @@ CREATE TABLE GroupHierarchy (
   HierarchyID int(11) NOT NULL auto_increment,
   ChildID int(11) NOT NULL default '0',
   ParentID int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (HierarchyID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `GroupHierarchy`
@@ -352,9 +352,9 @@ CREATE TABLE Institution (
   InstitutionID int(11) NOT NULL auto_increment,
   ShortName varchar(40) NOT NULL default '',
   LongName varchar(80) NOT NULL default '',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (InstitutionID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Institution`
@@ -372,10 +372,10 @@ CREATE TABLE Journal (
   Name varchar(128) NOT NULL default '',
   Publisher varchar(64) NOT NULL default '',
   URL varchar(240) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   Acronym varchar(8) default NULL,
   PRIMARY KEY  (JournalID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Journal`
@@ -391,9 +391,9 @@ CREATE TABLE Keyword (
   KeywordID int(11) NOT NULL auto_increment,
   ShortDescription varchar(32) default NULL,
   LongDescription text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (KeywordID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Keyword`
@@ -409,9 +409,9 @@ CREATE TABLE KeywordGroup (
   KeywordGroupID int(11) NOT NULL auto_increment,
   ShortDescription varchar(32) default NULL,
   LongDescription text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (KeywordGroupID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `KeywordGroup`
@@ -427,11 +427,11 @@ CREATE TABLE KeywordGrouping (
   KeywordGroupingID int(11) NOT NULL auto_increment,
   KeywordGroupID int(11) default NULL,
   KeywordID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (KeywordGroupingID),
   KEY KeywordID (KeywordID),
   KEY KeywordGroupID (KeywordGroupID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `KeywordGrouping`
@@ -447,10 +447,10 @@ CREATE TABLE MeetingModify (
   MeetingModifyID int(11) NOT NULL auto_increment,
   ConferenceID int(11) default NULL,
   GroupID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (MeetingModifyID),
   KEY ConferenceID (ConferenceID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `MeetingModify`
@@ -467,11 +467,11 @@ CREATE TABLE MeetingOrder (
   SessionOrder int(11) default NULL,
   SessionID int(11) default NULL,
   SessionSeparatorID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (MeetingOrderID),
   KEY SessionID (SessionID),
   KEY SessionSeparatorID (SessionSeparatorID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `MeetingOrder`
@@ -487,10 +487,10 @@ CREATE TABLE MeetingSecurity (
   MeetingSecurityID int(11) NOT NULL auto_increment,
   ConferenceID int(11) default NULL,
   GroupID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (MeetingSecurityID),
   KEY ConferenceID (ConferenceID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `MeetingSecurity`
@@ -508,13 +508,13 @@ CREATE TABLE Moderator (
   EventID int(11) NOT NULL default '0',
   SessionID int(11) NOT NULL default '0',
   SessionSeparatorID int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (ModeratorID),
   KEY Author (AuthorID),
   KEY Event (EventID),
   KEY Session (SessionID),
   KEY SepKey (SessionSeparatorID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Moderator`
@@ -532,12 +532,12 @@ CREATE TABLE Notification (
   Type varchar(32) default NULL,
   ForeignID int(11) default NULL,
   Period varchar(32) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   TextKey varchar(255) default NULL,
   PRIMARY KEY  (NotificationID),
   KEY EmailUserID (EmailUserID),
   KEY ForeignID (ForeignID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Notification`
@@ -554,11 +554,11 @@ CREATE TABLE RevisionAuthor (
   DocRevID int(11) NOT NULL default '0',
   AuthorID int(11) NOT NULL default '0',
   AuthorOrder int(11) default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (RevAuthorID),
   KEY DocRevID (DocRevID),
   KEY AuthorID (AuthorID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `RevisionAuthor`
@@ -574,11 +574,11 @@ CREATE TABLE RevisionEvent (
   RevEventID int(11) NOT NULL auto_increment,
   DocRevID int(11) NOT NULL default '0',
   ConferenceID int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (RevEventID),
   KEY MinorTopicID (ConferenceID),
   KEY DocRevID (DocRevID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `RevisionEvent`
@@ -594,11 +594,11 @@ CREATE TABLE RevisionModify (
   RevModifyID int(11) NOT NULL auto_increment,
   GroupID int(11) default NULL,
   DocRevID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (RevModifyID),
   KEY GroupID (GroupID),
   KEY DocRevID (DocRevID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `RevisionModify`
@@ -616,11 +616,11 @@ CREATE TABLE RevisionReference (
   JournalID int(11) default NULL,
   Volume char(32) default NULL,
   Page char(32) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (ReferenceID),
   KEY JournalID (JournalID),
   KEY DocRevID (DocRevID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `RevisionReference`
@@ -636,11 +636,11 @@ CREATE TABLE RevisionSecurity (
   RevSecurityID int(11) NOT NULL auto_increment,
   GroupID int(11) NOT NULL default '0',
   DocRevID int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (RevSecurityID),
   KEY Grp (GroupID),
   KEY Revision (DocRevID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `RevisionSecurity`
@@ -655,12 +655,12 @@ CREATE TABLE RevisionSecurity (
 CREATE TABLE RevisionTopic (
   RevTopicID int(11) NOT NULL auto_increment,
   DocRevID int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   TopicID int(11) NOT NULL default '0',
   PRIMARY KEY  (RevTopicID),
   KEY DocRevID (DocRevID),
   KEY TopicID (TopicID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `RevisionTopic`
@@ -676,13 +676,13 @@ CREATE TABLE SecurityGroup (
   GroupID int(11) NOT NULL auto_increment,
   Name char(16) NOT NULL default '',
   Description char(64) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   CanCreate int(11) default '0',
   CanAdminister int(11) default '0',
   CanView int(11) default '1',
   CanConfig int(11) default '0',
   PRIMARY KEY  (GroupID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `SecurityGroup`
@@ -700,13 +700,13 @@ CREATE TABLE Session (
   StartTime datetime default NULL,
   Title varchar(128) default NULL,
   Description text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   Location varchar(128) default NULL,
   AltLocation varchar(255) default NULL,
   ShowAllTalks int(11) default '0',
   PRIMARY KEY  (SessionID),
   KEY ConferenceID (ConferenceID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Session`
@@ -723,11 +723,11 @@ CREATE TABLE SessionOrder (
   TalkOrder int(11) default NULL,
   SessionTalkID int(11) default NULL,
   TalkSeparatorID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (SessionOrderID),
   KEY SessionTalkID (SessionTalkID),
   KEY TalkSeparatorID (TalkSeparatorID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `SessionOrder`
@@ -745,11 +745,11 @@ CREATE TABLE SessionSeparator (
   StartTime datetime default NULL,
   Title varchar(128) default NULL,
   Description text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   Location varchar(128) default NULL,
   PRIMARY KEY  (SessionSeparatorID),
   KEY ConferenceID (ConferenceID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `SessionSeparator`
@@ -769,11 +769,11 @@ CREATE TABLE SessionTalk (
   Time time default NULL,
   HintTitle varchar(128) default NULL,
   Note text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (SessionTalkID),
   KEY SessionID (SessionID),
   KEY DocumentID (DocumentID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `SessionTalk`
@@ -791,11 +791,11 @@ CREATE TABLE Signature (
   SignoffID int(11) default NULL,
   Note text,
   Signed int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (SignatureID),
   KEY EmailUserID (EmailUserID),
   KEY SignoffID (SignoffID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Signature`
@@ -811,10 +811,10 @@ CREATE TABLE Signoff (
   SignoffID int(11) NOT NULL auto_increment,
   DocRevID int(11) default NULL,
   Note text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (SignoffID),
   KEY DocRevID (DocRevID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Signoff`
@@ -830,11 +830,11 @@ CREATE TABLE SignoffDependency (
   SignoffDependencyID int(11) NOT NULL auto_increment,
   SignoffID int(11) default NULL,
   PreSignoffID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (SignoffDependencyID),
   KEY SignoffID (SignoffID),
   KEY PreSignoffID (PreSignoffID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `SignoffDependency`
@@ -859,7 +859,7 @@ CREATE TABLE Suppress (
   KEY Type (Type),
   KEY ForeignID (ForeignID),
   KEY TextKey (TextKey)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Suppress`
@@ -877,10 +877,10 @@ CREATE TABLE TalkSeparator (
   Time time default NULL,
   Title varchar(128) default NULL,
   Note text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (TalkSeparatorID),
   KEY SessionID (SessionID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `TalkSeparator`
@@ -896,9 +896,9 @@ CREATE TABLE Topic (
   TopicID int(11) NOT NULL auto_increment,
   ShortDescription varchar(64) default '',
   LongDescription text,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (TopicID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `Topic`
@@ -914,11 +914,11 @@ CREATE TABLE TopicHierarchy (
   TopicHierarchyID int(11) NOT NULL auto_increment,
   TopicID int(11) NOT NULL default '0',
   ParentTopicID int(11) NOT NULL default '0',
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (TopicHierarchyID),
   KEY Topic (TopicID),
   KEY Parent (ParentTopicID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `TopicHierarchy`
@@ -933,11 +933,11 @@ CREATE TABLE TopicHierarchy (
 CREATE TABLE TopicHint (
   TopicHintID int(11) NOT NULL auto_increment,
   SessionTalkID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   TopicID int(11) NOT NULL default '0',
   PRIMARY KEY  (TopicHintID),
   KEY SessionTalkID (SessionTalkID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `TopicHint`
@@ -953,10 +953,10 @@ CREATE TABLE UsersGroup (
   UsersGroupID int(11) NOT NULL auto_increment,
   EmailUserID int(11) default NULL,
   GroupID int(11) default NULL,
-  TimeStamp timestamp(14) NOT NULL,
+  TimeStamp timestamp NOT NULL,
   PRIMARY KEY  (UsersGroupID),
   KEY EmailUserID (EmailUserID)
-) TYPE=MyISAM;
+) Engine=MyISAM;
 
 --
 -- Dumping data for table `UsersGroup`


### PR DESCRIPTION
Another commit which is a tiny feature change is brought in with this request as I don't see how to exclude it.  Feel free to ignore it if you want.  These commits are on top of the tag docdb_8_8_6.
