### PR TITLE
Fix broken link to Statistics in public DocDB home page

### DIFF
--- a/DocDB/scripts/PublicInstall.csh
+++ b/DocDB/scripts/PublicInstall.csh
@@ -34,6 +34,8 @@ ln -sf ../../DocDB/ShowCalendar . # Could be optional
 ln -sf ../../DocDB/DocDBHelp .
 ln -sf ../../DocDB/DocDBHelp.xml .
 
+ln -sf ../../DocDB/Statistics .
+
 #ln -sf ../../DocDB/ProjectHelp.xml . # Project help may be different for public
 
 echo "If no errors were reported, things are safe for public access now."


### PR DESCRIPTION
The public DocDB home page shows a link to Statistics which is broken, because no symlink points to that script. I think the link should be created in PublicInstall.csh, unless there are security issues I am not aware of.