### PR TITLE
use array instead of hash for radio button group

### DIFF
--- a/DocDB/cgi/AdministerElements.pm
+++ b/DocDB/cgi/AdministerElements.pm
@@ -32,17 +32,14 @@ sub AdministerActions (%) {
   my $Form = $Params{-form}  || "";
   my $AddTransfer = $Params{-addTransfer}  || $FALSE;
 
-  my %Action = ();
+  my @Action = ('New', 'Delete', 'Modify');
 
-  $Action{Delete}    = "Delete";
-  $Action{New}       = "New";
-  $Action{Modify}    = "Modify";
   if ($AddTransfer) {
     $Action{Transfer}    = "Transfer";
   }
   print FormElementTitle(-helplink => "admaction", -helptext => "Action");
   print $query -> radio_group(-name => "admaction",
-                              -values => \%Action, -default => "-",
+                              -values => \@Action, -default => "-",
                               -onclick => "disabler_$Form();");
 };
 


### PR DESCRIPTION
On any of the administration pages with new/delete/modify radio buttons (e.g. AdministerForm), our DocDB installation (DocDB 8.8.6) orders the radio buttons randomly. I don't think this can be intended behavior, and AuthorAdminDisable.js expects a consistent ordering of [new, delete, modify].

I think this is a bug in the AdministerActions method of AdministerElements.pm, which exists in trunk as well as in 8.8.6. The button names are stored in a hash when an array is appropriate. This commit fixes the bug.