### PR TITLE
8.8.9 jp

### DIFF
--- a/DocDB/cgi/AddFiles
+++ b/DocDB/cgi/AddFiles
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: AddFiles
 # Description: Adds downloaded files to the database and filesystem

--- a/DocDB/cgi/AddFilesForm
+++ b/DocDB/cgi/AddFilesForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: AddFilesForm
 # Description: An entry form to add files to an existing document

--- a/DocDB/cgi/AdministerElements.pm
+++ b/DocDB/cgi/AdministerElements.pm
@@ -29,17 +29,14 @@ sub AdministerActions (%) {
   my $Form = $Params{-form}  || "";
   my $AddTransfer = $Params{-addTransfer}  || $FALSE;
 
-  my %Action = ();
+  my @Action = ('New', 'Delete', 'Modify');
 
-  $Action{Delete}    = "Delete";
-  $Action{New}       = "New";
-  $Action{Modify}    = "Modify";
   if ($AddTransfer) {
     $Action{Transfer}    = "Transfer";
   }
   print FormElementTitle(-helplink => "admaction", -helptext => "Action");
   print $query -> radio_group(-name => "admaction",
-                              -values => \%Action, -default => "-",
+                              -values => \@Action, -default => "-",
                               -onclick => "disabler_$Form();");
 };
 

--- a/DocDB/cgi/AdministerForm
+++ b/DocDB/cgi/AdministerForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: AdministerForm
 # Description: This single form provides a number of interfaces to admin

--- a/DocDB/cgi/AdministerHome
+++ b/DocDB/cgi/AdministerHome
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #        Name: $RCSfile$
 # Description: Group administrative actions into one page
 #

--- a/DocDB/cgi/AuthorAdd
+++ b/DocDB/cgi/AuthorAdd
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: AuthorAdd
 # Description: Adds an author into the DB list of authors.

--- a/DocDB/cgi/AuthorAddForm
+++ b/DocDB/cgi/AuthorAddForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: A simple script to allow new author addition (no changes possible)
 #

--- a/DocDB/cgi/AuthorAdminister
+++ b/DocDB/cgi/AuthorAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: This script is called by AdministerForm and does administration
 #              on Authors in the DB. AddAuthor is simpler and can only add

--- a/DocDB/cgi/BulkCertificateInsert
+++ b/DocDB/cgi/BulkCertificateInsert
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: Allows an administrator to create entries for certificate users in EmailUser
 #

--- a/DocDB/cgi/CertificateApplyForm
+++ b/DocDB/cgi/CertificateApplyForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 

--- a/DocDB/cgi/ConfirmTalkHint
+++ b/DocDB/cgi/ConfirmTalkHint
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: Script to confirm a match between a talk entered in the agenda
 #              and a document

--- a/DocDB/cgi/CustomListForm
+++ b/DocDB/cgi/CustomListForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: CustomListForm
 # Description: Allow users, admins, and meeting organizers to change how various

--- a/DocDB/cgi/DeleteConfirm
+++ b/DocDB/cgi/DeleteConfirm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #        Name: $RCSfile$
 # Description: Displays the document (or document and version)
 #              to be deleted and requests the admin password.

--- a/DocDB/cgi/DeleteDocument
+++ b/DocDB/cgi/DeleteDocument
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #        Name: $RCSfile$
 # Description: This script is called by DeleteConfirm to actually delete
 #              the requested document, all associated entries in the DB,

--- a/DocDB/cgi/DisplayMeeting
+++ b/DocDB/cgi/DisplayMeeting
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: DisplayMeeting
 # Description: Displays talks for a meeting or just a session of a meeting

--- a/DocDB/cgi/DocDBHelp
+++ b/DocDB/cgi/DocDBHelp
@@ -54,15 +54,15 @@ my ($DefaultText, $DefaultTitle, $ProjectText, $ProjectTitle, $Action);
 
 my $HelpXML = XMLin("DocDBHelp.xml");
 
-$DefaultText = %{$HelpXML->{entry}{$helpterm}}->{text};
-$DefaultTitle = %{$HelpXML->{entry}{$helpterm}}->{title};
+$DefaultText = $HelpXML->{entry}{$helpterm}->{text};
+$DefaultTitle = $HelpXML->{entry}{$helpterm}->{title};
 
 if ($ProjectHelp) {
   my $ProjectXML = XMLin("ProjectHelp.xml");
 
-  $ProjectText = %{$ProjectXML->{entry}{$helpterm}}->{text};
-  $ProjectTitle = %{$ProjectXML->{entry}{$helpterm}}->{title};
-  $Action = %{$ProjectXML->{entry}{$helpterm}}->{action};
+  $ProjectText = $ProjectXML->{entry}{$helpterm}->{text};
+  $ProjectTitle = $ProjectXML->{entry}{$helpterm}->{title};
+  $Action = $ProjectXML->{entry}{$helpterm}->{action};
 }
 
 # Remove line breaks and XML element tags

--- a/DocDB/cgi/DocDBHelp
+++ b/DocDB/cgi/DocDBHelp
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: DocDBHelp
 # Description: Usually called as a pop-up, this looks up in docdb.hlp

--- a/DocDB/cgi/DocDBInstructions
+++ b/DocDB/cgi/DocDBInstructions
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: The instructions for DocDB. This is mostly HTML, but making
 #              it a script allows us to eliminate parts of it that we don't want

--- a/DocDB/cgi/DocTypeAdminister
+++ b/DocDB/cgi/DocTypeAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: DocTypeAdminister
 # Description: This script is called by AdministerForm and does administration

--- a/DocDB/cgi/DocumentAddForm
+++ b/DocDB/cgi/DocumentAddForm
@@ -522,6 +522,7 @@ SecurityScroll(-addpublic => 'true',
                -helplink  => 'security',
                -helptext  => $SecurityText,
                -multiple  => $TRUE,
+               -permission=> 'CanView',
                -default   => \@SecurityDefaults);
 print "</td>\n";
 if ($EnhancedSecurity) {
@@ -530,6 +531,7 @@ if ($EnhancedSecurity) {
                  -helplink  => 'modifygroups',
                  -helptext  => 'Can Modify',
                  -multiple  => $TRUE,
+                 -permission=> 'CanCreate',
                  -default   => \@ModifyDefaults);
   print "</td>\n";
 }

--- a/DocDB/cgi/DocumentAddForm
+++ b/DocDB/cgi/DocumentAddForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: DocumentAddForm
 # Description: The main form to add or modify documents or metadata

--- a/DocDB/cgi/DocumentDatabase
+++ b/DocDB/cgi/DocumentDatabase
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: DocumentDatabase
 # Description: The Document Database homepage. Give the user various ways to

--- a/DocDB/cgi/EditTalkInfo
+++ b/DocDB/cgi/EditTalkInfo
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ShowTalkNote
 # Description: Usually called as a pop-up, this will look up the note for a talk

--- a/DocDB/cgi/EmailAdminister
+++ b/DocDB/cgi/EmailAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: EmailAdminister
 # Description: This script is called by EmailAdministerForm and does

--- a/DocDB/cgi/EmailAdministerForm
+++ b/DocDB/cgi/EmailAdministerForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: EmailAdministerForm
 # Description: This script provides a form to administer users receiving

--- a/DocDB/cgi/EmailLogin
+++ b/DocDB/cgi/EmailLogin
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: The login form to a users e-mail notification account
 #

--- a/DocDB/cgi/EventAdministerForm
+++ b/DocDB/cgi/EventAdministerForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: EventAdministerForm
 # Description: This single form provides interfaces to admin tools for

--- a/DocDB/cgi/ExternalDocDBAdministerForm
+++ b/DocDB/cgi/ExternalDocDBAdministerForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ExternalDocDBAdministerForm
 # Description: Allows the administrator to add knowledge of other DocDBs.

--- a/DocDB/cgi/GroupAdminister
+++ b/DocDB/cgi/GroupAdminister
@@ -246,8 +246,8 @@ if      ($Action eq "Delete") { # Delete group
 } elsif ($Action eq "New") { # Create new groups
   push @ActionStack,"Adding a new group.";
   my $GroupInsert = $dbh->prepare(
-   "insert into SecurityGroup (GroupID,Name,Description,CanCreate,CanAdminister,CanView,CanConfig) ".
-                      "values (0,?,?,?,?,?,0)");
+   "insert into SecurityGroup (Name,Description,CanCreate,CanAdminister,CanView,CanConfig) ".
+                      "values (?,?,?,?,?,0)");
 
   $GroupInsert -> execute($Name,$Description,$Create,$Admin,$View);
   $ParentID = $GroupInsert -> {mysql_insertid}; # Works with MySQL only

--- a/DocDB/cgi/GroupAdminister
+++ b/DocDB/cgi/GroupAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: GroupAdminister
 # Description: This script is called by GroupAdministerForm and does

--- a/DocDB/cgi/GroupAdminister
+++ b/DocDB/cgi/GroupAdminister
@@ -64,10 +64,15 @@ my $NoPerm = $Untaint -> extract(-as_printable => "remove") || "";
 my $RemoveChildren = $Untaint -> extract(-as_printable => "removesubs") || "";
 
 if ($View)           {$View   = 1;} # Make sure they are in format MySQL is expecting
+else                 {$View   = 0;}
 if ($Create)         {$Create = 1;}
+else                 {$Create = 0;}
 if ($Admin)          {$Admin  = 1;}
+else                 {$Admin  = 0;}
 if ($NoPerm)         {$NoPerm = 1;}
+else                 {$NoPerm = 0;}
 if ($RemoveChildren) {$RemoveChildren = 1;}
+else                 {$RemoveChildren = 0;}
 
 $dbh   = DBI->connect('DBI:mysql:'.$db_name.':'.$db_host,$Username,$Password);
 

--- a/DocDB/cgi/GroupAdministerForm
+++ b/DocDB/cgi/GroupAdministerForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: This script provides a form to administer groups in
 #              the DocDB and shows the relationships between groups.

--- a/DocDB/cgi/InstitutionAdminister
+++ b/DocDB/cgi/InstitutionAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: This script is called by AdministerForm and does administration
 #              on Institutions in the DB. This script adds, modifies and deletes

--- a/DocDB/cgi/JournalAdminister
+++ b/DocDB/cgi/JournalAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: This script is called by AdministerForm and does administration
 #              on journals in the DB. This script adds, modifies and deletes

--- a/DocDB/cgi/KeywordAdministerForm
+++ b/DocDB/cgi/KeywordAdministerForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: Add keywords or keyword groups to the keyword list
 #              The keyword list is used indirectly to lookup approved keywords

--- a/DocDB/cgi/KeywordGroupAdminister
+++ b/DocDB/cgi/KeywordGroupAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: This script is called by KeywordAdministerForm and does administration
 #              on Keyword Groups in the DB. This script adds, modifies and deletes

--- a/DocDB/cgi/KeywordListAdminister
+++ b/DocDB/cgi/KeywordListAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: This script is called by KeywordAdministerForm and does administration
 #              on the Keyword table in the DB.

--- a/DocDB/cgi/ListAllMeetings
+++ b/DocDB/cgi/ListAllMeetings
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ListAllMeetings
 # Description: Generates a nice table of all meetings, either for viewing or modification

--- a/DocDB/cgi/ListAuthors
+++ b/DocDB/cgi/ListAuthors
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 

--- a/DocDB/cgi/ListBy
+++ b/DocDB/cgi/ListBy
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Generate tables of document for various input parameters

--- a/DocDB/cgi/ListEventsBy
+++ b/DocDB/cgi/ListEventsBy
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ListEventsBy
 # Description: This script lists events and sessions based on the topic(s) or

--- a/DocDB/cgi/ListGroupUsers
+++ b/DocDB/cgi/ListGroupUsers
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: EmailAdministerForm
 # Description: This script provides a form to administer users receiving

--- a/DocDB/cgi/ListGroups
+++ b/DocDB/cgi/ListGroups
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 

--- a/DocDB/cgi/ListKeywords
+++ b/DocDB/cgi/ListKeywords
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ListKeywords
 # Description: Lists the managed keywords.

--- a/DocDB/cgi/ListManagedDocuments
+++ b/DocDB/cgi/ListManagedDocuments
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 

--- a/DocDB/cgi/ListTopics
+++ b/DocDB/cgi/ListTopics
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 

--- a/DocDB/cgi/ListTypes
+++ b/DocDB/cgi/ListTypes
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 

--- a/DocDB/cgi/MeetingModify
+++ b/DocDB/cgi/MeetingModify
@@ -531,6 +531,7 @@ if ($NoSessions) {
                  -helplink  => 'meetingviewgroups',
                  -helptext  => 'Viewable by',
                  -multiple  => $TRUE,
+                 -permission=> 'CanView',
                  -default   => \@MeetingViewDefaults,
                  -size      => 8);
   print "</td>\n";
@@ -541,6 +542,7 @@ if ($NoSessions) {
                  -helplink => 'meetingmodifygroups',
                  -helptext => 'Modifiable by',
                  -multiple => $TRUE,
+                 -permission=> 'CanCreate',
                  -default  => \@MeetingModifyDefaults,
                  -size     => 8);
   print "</td>\n";

--- a/DocDB/cgi/MeetingModify
+++ b/DocDB/cgi/MeetingModify
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Modify sessions of meeting the shell of a meeting. Calls itself

--- a/DocDB/cgi/ModifyHome
+++ b/DocDB/cgi/ModifyHome
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ModifyHome
 # Description: The second "homepage" for adding documents and other metadata

--- a/DocDB/cgi/ProcessDocumentAdd
+++ b/DocDB/cgi/ProcessDocumentAdd
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ProcessDocumentAdd
 # Description: Receives the output of DocumentAddForm and creates or updates the document

--- a/DocDB/cgi/RetrieveArchive
+++ b/DocDB/cgi/RetrieveArchive
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: RetrieveArchive
 # Description: Create an archive (.zip, .tar, .tar.gz) file of the document

--- a/DocDB/cgi/RetrieveFile
+++ b/DocDB/cgi/RetrieveFile
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Get a file from a document. Automatically or by extension if possible.

--- a/DocDB/cgi/SSOAccessApply
+++ b/DocDB/cgi/SSOAccessApply
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: SSOAccessApply
 # Description: Deal with the process of having a user apply to use DocDB via their SSO login. This is mostly

--- a/DocDB/cgi/Search
+++ b/DocDB/cgi/Search
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Search on documents in local DocDB

--- a/DocDB/cgi/SearchForm
+++ b/DocDB/cgi/SearchForm
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: SearchForm
 # Description: Build the input form for the "Advanced" (formerly normal) DocDB Search

--- a/DocDB/cgi/SecurityHTML.pm
+++ b/DocDB/cgi/SecurityHTML.pm
@@ -39,6 +39,7 @@ sub SecurityScroll (%) {
   my $Format    =   $Params{-format}    || "short";
   my $Size      =   $Params{-size}      || 10;
   my $Disabled  =   $Params{-disabled}  || $FALSE;
+  my $Permission=   $Params{-permission}|| "";
   my @GroupIDs  = @{$Params{-groupids}};
   my @Default   = @{$Params{-default}};
 
@@ -51,7 +52,17 @@ sub SecurityScroll (%) {
   &GetSecurityGroups;
 
   unless (@GroupIDs) {
-    @GroupIDs = keys %SecurityGroups;
+    if($Permission){
+      @GroupIDs = ();
+      foreach my $ID (keys %SecurityGroups) {
+        if($SecurityGroups{$ID}{$Permission}){
+          push @GroupIDs,$ID;
+        }
+      }
+    }
+    else{
+      @GroupIDs = keys %SecurityGroups;
+    }
   }
 
   my %GroupLabels = ();

--- a/DocDB/cgi/SelectEmailPrefs
+++ b/DocDB/cgi/SelectEmailPrefs
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: SelectEmailPrefs.pm
 # Description: Change preferences for what/when to be notified of document

--- a/DocDB/cgi/SelectGroups
+++ b/DocDB/cgi/SelectGroups
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Author:  Eric Vaandering
 #          Date:  22 May 2005

--- a/DocDB/cgi/SelectPrefs
+++ b/DocDB/cgi/SelectPrefs
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Main page for selecting various user-level preferences

--- a/DocDB/cgi/SessionModify
+++ b/DocDB/cgi/SessionModify
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Add talks to sessions of a meeting. Calls itself. In future,

--- a/DocDB/cgi/SessionModify
+++ b/DocDB/cgi/SessionModify
@@ -591,6 +591,7 @@ if ($SingleSession) {
                  -helplink  => 'meetingviewgroups',
                  -helptext  => 'Viewable by',
                  -multiple  => true,
+                 -permission=> 'CanView',
                  -default   => \@MeetingViewDefaults,
                  -size      => 8);
   print "</td>\n";
@@ -599,6 +600,7 @@ if ($SingleSession) {
                  -helplink  => 'meetingmodifygroups',
                  -helptext  => 'Modifiable by',
                  -multiple  => true,
+                 -permission=> 'CanCreate',
                  -default   => \@MeetingModifyDefaults,
                  -size      => 8);
   print "</td>\n";

--- a/DocDB/cgi/SetGroups
+++ b/DocDB/cgi/SetGroups
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Author:  Eric Vaandering
 #          Date:  22 May 2005

--- a/DocDB/cgi/SetPrefs
+++ b/DocDB/cgi/SetPrefs
@@ -1,5 +1,8 @@
 #! /usr/bin/env perl
 
+use lib ".";
+
+
 #        Name: SetPrefs
 # Description: Reads form parameters from SelectPrefs and stores user's
 #              selections in a group of cookies, one for each preference.

--- a/DocDB/cgi/ShowCalendar
+++ b/DocDB/cgi/ShowCalendar
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Print out various types of calendar (monthly/yearly/daily) and the events

--- a/DocDB/cgi/ShowDocument
+++ b/DocDB/cgi/ShowDocument
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ShowDocument
 # Description: Display a document, its metadata, links to other versions and links to the files

--- a/DocDB/cgi/ShowTalkNote
+++ b/DocDB/cgi/ShowTalkNote
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: ShowTalkNote
 # Description: Usually called as a pop-up, this will look up the note for a talk

--- a/DocDB/cgi/SignRevision
+++ b/DocDB/cgi/SignRevision
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: SignRevision
 # Description: Sign (approve) a revision of a document

--- a/DocDB/cgi/SignatureReport
+++ b/DocDB/cgi/SignatureReport
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 #

--- a/DocDB/cgi/SignoffChooser
+++ b/DocDB/cgi/SignoffChooser
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Lists the people who can sign a document and helps the user

--- a/DocDB/cgi/Statistics
+++ b/DocDB/cgi/Statistics
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: Gather and display aggregate statistics on DocDB
 #

--- a/DocDB/cgi/TopicAdminister
+++ b/DocDB/cgi/TopicAdminister
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Description: This script is called by AdministerForm and does administration
 #              on Topics in the DB. TopicAdd is simpler and can only add

--- a/DocDB/cgi/UserAccessApply
+++ b/DocDB/cgi/UserAccessApply
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: UserAccessApply
 # Description: Deal with the process of having a user apply to use DocDB via their certificate

--- a/DocDB/cgi/VEntryOutput.pm
+++ b/DocDB/cgi/VEntryOutput.pm
@@ -97,8 +97,23 @@ sub ICalEventEntry {
 
   my $ICalFormatter = DateTime::Format::ICal->new();
 
-  $EventHash{dtstart} = $ICalFormatter->format_datetime($Conferences{$EventID}{StartDateTime});
-  $EventHash{dtend}   = $ICalFormatter->format_datetime($Conferences{$EventID}{EndDateTime});
+  my $formated_dtstart = $ICalFormatter->format_datetime($Conferences{$EventID}{StartDateTime});
+  if ($formated_dtstart =~ m/TZID=/) {
+    my ($timezone, $timestamp) = split(':', $formated_dtstart, 2);
+    $EventHash{'dtstart;'.$timezone} = $timestamp
+  }
+  else {
+    $EventHash{dtstart} = $formated_dtstart
+  }
+  my $formated_dtend = $ICalFormatter->format_datetime($Conferences{$EventID}{EndDateTime});
+  if ($formated_dtend =~ m/TZID=/) {
+    my ($timezone, $timestamp) = split(':', $formated_dtend, 2);
+    $EventHash{'dtend;'.$timezone} = $timestamp
+  }
+  else {
+    $EventHash{dtend} = $formated_dtend
+  }
+
   $EventHash{"LAST-MODIFIED"} = $ICalFormatter->format_datetime($Conferences{$EventID}{ModifiedDateTime});
 
   foreach my $Key (keys %ICalMapping) {
@@ -154,8 +169,23 @@ sub ICalSessionEntry {
   SessionEndTime($SessionID);
   my $ICalFormatter = DateTime::Format::ICal->new();
 
-  $SessionHash{dtstart} = $ICalFormatter->format_datetime($Sessions{$SessionID}{StartDateTime});
-  $SessionHash{dtend}   = $ICalFormatter->format_datetime($Sessions{$SessionID}{EndDateTime});
+  my $formated_dtstart = $ICalFormatter->format_datetime($Sessions{$SessionID}{StartDateTime});
+  if ($formated_dtstart =~ m/TZID=/) {
+    my ($timezone, $timestamp) = split(':', $formated_dtstart, 2);
+    $SessionHash{'dtstart;'.$timezone} = $timestamp
+  }
+  else {
+    $SessionHash{dtstart} = $formated_dtstart
+  }
+  my $formated_dtend = $ICalFormatter->format_datetime($Sessions{$SessionID}{EndDateTime});
+  if ($formated_dtend =~ m/TZID=/) {
+    my ($timezone, $timestamp) = split(':', $formated_dtend, 2);
+    $SessionHash{'dtend;'.$timezone} = $timestamp
+  }
+  else {
+    $SessionHash{dtend} = $formated_dtend
+  }
+  
   $SessionHash{"LAST-MODIFIED"} = $ICalFormatter->format_datetime($Sessions{$SessionID}{ModifiedDateTime});
 
   foreach my $Key (keys %ICalMapping) {

--- a/DocDB/cgi/WatchDocument
+++ b/DocDB/cgi/WatchDocument
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: WatchDocument
 # Description: Change preferences for what/when to be notified of document

--- a/DocDB/cgi/XMLUpload
+++ b/DocDB/cgi/XMLUpload
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 #        Name: $RCSfile$
 # Description: Allows the user to provide an XML file with all the data describing a document.

--- a/DocDB/cgi/XSearch
+++ b/DocDB/cgi/XSearch
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 #

--- a/DocDB/scripts/CheckModules
+++ b/DocDB/scripts/CheckModules
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 #

--- a/DocDB/scripts/CheckSubUsed
+++ b/DocDB/scripts/CheckSubUsed
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 #

--- a/DocDB/scripts/ContentSearch.template
+++ b/DocDB/scripts/ContentSearch.template
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 #

--- a/DocDB/scripts/FullList
+++ b/DocDB/scripts/FullList
@@ -1,4 +1,8 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
+#
 #
 # Description: Invoke with "-u username" which will generate an HTML list of  
 #              all the documents that user is allowed to see. Redirect to a 

--- a/DocDB/scripts/NotifyDigest
+++ b/DocDB/scripts/NotifyDigest
@@ -1,4 +1,7 @@
 #! /usr/bin/env perl
+
+use lib ".";
+
 #
 # Author Eric Vaandering (ewv@fnal.gov)
 #


### PR DESCRIPTION
Hey Eric,

When deploying DocDB here I ran into a few issues (some only in my personal computer installation based on an up to date ArchLinux). I also added in a few changes that might be of general interest. Feel free to cherry-pick what you find interesting or let me know what you want so I can make a separate pull request.

As I had the same issue with changing boxes as @meeg I cherry picked the corresponding commit that was already proposed.

For reference commits  196b035  0fc333e 026adce were needed to get DocDB running on ArchLinux, though the first 2 ones might be of general interest.

Commit 4f28fed solves an issue I had with importing events from DocDB into a calendar application (I tested both korganizer and the apple calendar app) where the timezone separation from DTSTART and DTEND with a colon was not recognized so no event was added.

Commit 0bcb322 fixes a deprecation warning that was poluting my apache logs

Commit 5348f78 changes which users are shown on the document/event forms to show only users that have the permission to view in "Can View" and only users with modify permissions in "Can Modify".

Cheers,
João Pedro